### PR TITLE
[SB-2006] Add Ons

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
-  "name": "openactive/models",
+  "name": "playfinder/openactive-models",
   "description": "Library for working with the Openactive Specification",
   "type": "library",
   "license": "MIT",
   "require": {
-    "php": "^5.6 | ^7.0 | ^8.0",
+    "php": "^7.4 | ^8.0",
     "ext-json": "*"
   },
   "autoload": {
@@ -20,7 +20,8 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.15",
     "squizlabs/php_codesniffer": "^3.5",
-    "phpunit/phpunit": "^5.7 | ^9.0"
+    "phpunit/phpunit": "^5.7 | ^9.0",
+    "psy/psysh": "^0.11.12"
   },
   "scripts": {
     "fix": "./vendor/bin/php-cs-fixer fix",

--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -129,9 +129,12 @@ class BaseModel implements SerializerInterface, TypeCheckerInterface
 
         if ($type) {
             // If type is schema.org target right namespace
-            if(strpos($type, "schema:") === 0) {
-                $classname = "\\OpenActive\\Models\\SchemaOrg\\".
+            if (strpos($type, "schema:") === 0) {
+                $classname = "\\OpenActive\\Models\\SchemaOrg\\" .
                     str_replace("schema:", "", $type);
+            } elseif (strpos($type, "playfinder:") === 0) {
+                $classname = "\\OpenActive\\Models\\Playfinder\\" .
+                    str_replace("playfinder:", "", $type);
             } else {
                 $classname = "\\OpenActive\\Models\\OA\\".
                     // If the type is in beta, remove the prefix to resolve the model

--- a/src/Models/Playfinder/AddOn.php
+++ b/src/Models/Playfinder/AddOn.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace OpenActive\Models\Playfinder;
+
+use OpenActive\Models\OA\Offer;
+use OpenActive\Models\OA\PriceSpecification;
+use OpenActive\Models\SchemaOrg\Product;
+
+class AddOn extends Product
+{
+    /**
+     * @var PriceSpecification|null
+     */
+    private ?PriceSpecification $priceSpecification = null;
+
+    /**
+     * @var Offer[]|string[]
+     */
+    protected $offers;
+
+    public static function getType()
+    {
+        return "playfinder:AddOn";
+    }
+
+    public static function fieldList()
+    {
+        $fields = [
+            'priceSpecification' => 'priceSpecification',
+        ];
+
+        return array_merge(parent::fieldList(), $fields);
+    }
+
+    /**
+     * @return PriceSpecification|null
+     */
+    public function getPriceSpecification(): ?PriceSpecification
+    {
+        return $this->priceSpecification;
+    }
+
+    /**
+     * @param PriceSpecification|null $priceSpecification
+     */
+    public function setPriceSpecification(?PriceSpecification $priceSpecification): void
+    {
+        $this->priceSpecification = $priceSpecification;
+    }
+
+    /**
+     * @return  Offer[]|string[]
+     */
+    public function getOffers(): array
+    {
+        return $this->offers;
+    }
+
+    /**
+     * @param Offer[]|string[] $offers
+     */
+    public function setOffers($offers): void
+    {
+        $this->offers = $offers;
+    }
+}

--- a/src/Models/Playfinder/IndividualFacilityUse.php
+++ b/src/Models/Playfinder/IndividualFacilityUse.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace OpenActive\Models\Playfinder;
+
+class IndividualFacilityUse extends \OpenActive\Models\OA\IndividualFacilityUse
+{
+    /**
+     * @var AddOn[] $addOns
+     */
+    private array $addOns = [];
+
+    public static function getType()
+    {
+        return "playfinder:IndividualFacilityUse";
+    }
+
+    public static function fieldList() {
+        $fields = [
+            "addOns" => "beta:addOns",
+        ];
+
+        return array_merge(parent::fieldList(), $fields);
+    }
+
+    /**
+     * @return AddOn[]
+     */
+    public function getAddOns(): array
+    {
+        return $this->addOns;
+    }
+
+    /**
+     * @var AddOn[] $addOns
+     */
+    public function setAddOns(array $addOns): void
+    {
+        $this->addOns = $addOns;
+    }
+}

--- a/src/Models/Playfinder/OrderItem.php
+++ b/src/Models/Playfinder/OrderItem.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace OpenActive\Models\Playfinder;
+
+use OpenActive\Models\OA;
+
+class OrderItem extends OA\OrderItem
+{
+    /**
+     * @var OrderItem|OA\OrderItem|null
+     */
+    private ?OA\OrderItem $parentOrderItem = null;
+
+    public static function getType()
+    {
+        return "playfinder:OrderItem";
+    }
+
+    public static function fieldList() {
+        $fields = [
+            "parentOrderItem" => "beta:parentOrderItem",
+        ];
+
+        return array_merge(parent::fieldList(), $fields);
+    }
+
+    public function getParentOrderItem(): ?OA\OrderItem
+    {
+        return $this->parentOrderItem;
+    }
+
+    public function setParentOrderItem(?OA\OrderItem $orderItem): void
+    {
+        $this->parentOrderItem = $orderItem;
+    }
+}

--- a/src/Modifiers/AddOnModifier.php
+++ b/src/Modifiers/AddOnModifier.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace OpenActive\Modifiers;
+
+use OpenActive\Models\OA;
+use OpenActive\Models\Playfinder\OrderItem;
+
+class AddOnModifier
+{
+    public function __invoke($class, $key, $value)
+    {
+        if (is_subclass_of($class, OA\Order::class) && $key === 'orderedItem') {
+            return array_map(
+                fn (array $item) => new OrderItem($item),
+                $value
+            );
+        }
+        return $value;
+    }
+}

--- a/tests/Models/Playfinder/AddOnTest.php
+++ b/tests/Models/Playfinder/AddOnTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace OpenActive\Models\Tests\Unit\Playfinder;
+
+use OpenActive\Models\OA\Offer;
+use OpenActive\Models\OA\PriceSpecification;
+use OpenActive\Models\OA\QuantitativeValue;
+use OpenActive\Models\Playfinder\AddOn;
+use PHPUnit\Framework\TestCase;
+
+class AddOnTest extends TestCase
+{
+    public function testDeserialises()
+    {
+        $addOn = AddOn::deserialize('{
+            "@id": "https://example.com/openactive/add-ons/b9372482-8d6e-4d89-9160-58fa52d86944",
+            "@type": "playfinder:AddOn",
+            "@context": [
+                "https://openactive.io/",
+                "https://openactive.io/ns-beta"
+            ],
+            "name": "Junior Racket Hire",
+            "priceSpecification": {
+                "@type": "PriceSpecification",
+                "eligibleQuantity": {
+                    "@type": "QuantitativeValue",
+                    "minValue": 0,
+                    "maxValue": 4
+                }
+            },
+            "offers": [
+                {
+                    "@type": "Offer",
+                    "@id": "https://example.com/openactive/add-ons/b9372482-8d6e-4d89-9160-58fa52d86944#offer",
+                    "priceCurrency": "GBP",
+                    "price": 10.3
+                }
+            ]
+        }');
+        $this->assertInstanceOf(AddOn::class, $addOn);
+        $this->assertEquals('Junior Racket Hire', $addOn->getName());
+        $this->assertEquals(0, $addOn->getPriceSpecification()->getEligibleQuantity()->getMinValue());
+        $this->assertEquals(4, $addOn->getPriceSpecification()->getEligibleQuantity()->getMaxValue());
+        $this->assertCount(1, $addOn->getOffers());
+        $this->assertEquals(10.3, $addOn->getOffers()[0]->getPrice());
+    }
+    public function testSerialises()
+    {
+        $addOn = new AddOn([
+            'id' => 'https://example.com/openactive/add-ons/b9372482-8d6e-4d89-9160-58fa52d86944',
+            'name' => 'Junior Racket Hire',
+            'priceSpecification' => new PriceSpecification([
+                'eligibleQuantity' => new QuantitativeValue([
+                    'minValue' => 0,
+                    'maxValue' => 4,
+                ])
+            ]),
+            'offers' => [new Offer([
+                'id' => 'https://example.com/openactive/add-ons/b9372482-8d6e-4d89-9160-58fa52d86944#offer',
+                'priceCurrency' => 'GBP',
+                'price' => 10.3
+            ])]
+        ]);
+        $this->assertJsonStringEqualsJsonString('{
+            "@id": "https://example.com/openactive/add-ons/b9372482-8d6e-4d89-9160-58fa52d86944",
+            "@type": "playfinder:AddOn",
+            "@context": [
+                "https://openactive.io/",
+                "https://openactive.io/ns-beta"
+            ],
+            "name": "Junior Racket Hire",
+            "priceSpecification": {
+                "@type": "PriceSpecification",
+                "eligibleQuantity": {
+                    "@type": "QuantitativeValue",
+                    "minValue": 0,
+                    "maxValue": 4
+                }
+            },
+            "offers": [
+                {
+                    "@type": "Offer",
+                    "@id": "https://example.com/openactive/add-ons/b9372482-8d6e-4d89-9160-58fa52d86944#offer",
+                    "priceCurrency": "GBP",
+                    "price": 10.3
+                }
+            ]
+        }', AddOn::serialize($addOn));
+    }
+}

--- a/tests/Models/Playfinder/IndividualFacilityUseTest.php
+++ b/tests/Models/Playfinder/IndividualFacilityUseTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace OpenActive\Models\Tests\Models\Playfinder;
+
+use OpenActive\Enums\PropertyEnumeration\Provider;
+use OpenActive\Models\OA\Concept;
+use OpenActive\Models\OA\Offer;
+use OpenActive\Models\OA\Organization;
+use OpenActive\Models\OA\PriceSpecification;
+use OpenActive\Models\OA\QuantitativeValue;
+use OpenActive\Models\Playfinder\AddOn;
+use OpenActive\Models\Playfinder\IndividualFacilityUse;
+use PHPUnit\Framework\TestCase;
+
+class IndividualFacilityUseTest extends TestCase
+{
+    public function testDeserialises()
+    {
+        $facility = IndividualFacilityUse::deserialize('{
+            "@id": "https://example.com/api/openactive/individual-facility-uses/d7fb4341-756a-41a8-ad17-4b8f6b574bb6",
+            "@type": "playfinder:IndividualFacilityUse",
+            "@context": [
+              "https://openactive.io/",
+              "https://openactive.io/ns-beta"
+            ],
+            "identifier": "d7fb4341-756a-41a8-ad17-4b8f6b574bb6",
+            "name": "Football 11-a-side",
+            "url": "https://example.com/api/openactive/individual-facility-uses/d7fb4341-756a-41a8-ad17-4b8f6b574bb6",
+            "activity": [
+              {
+                "@type": "Concept",
+                "@id": "https://openactive.io/activity-list#117e7f70-6c42-4b1f-a3bb-620b63ea263l",
+                "inScheme": "https://openactive.io/activity-list",
+                "prefLabel": "11-a-side"
+              }
+            ],
+            "beta:addOns": [{
+              "@id": "https://example.com/openactive/add-ons/de505ce7-351f-4f8f-90c4-29887947a603",
+              "@type": "playfinder:AddOn",
+              "name": "Adult Racket Hire",
+              "priceSpecification": {
+                "@type": "PriceSpecification",
+                "eligibleQuantity": {
+                  "@type": "QuantitativeValue",
+                  "minValue": 0,
+                  "maxValue": 4
+                }
+              },
+              "offers": [
+                {
+                  "@type": "Offer",
+                  "@id": "https://example.com/openactive/add-ons/de505ce7-351f-4f8f-90c4-29887947a603#offer",
+                  "priceCurrency": "GBP",
+                  "price": 1.5
+                }
+              ]
+            }, {
+              "@id": "https://example.com/openactive/add-ons/b9372482-8d6e-4d89-9160-58fa52d86944",
+              "@type": "playfinder:AddOn",
+              "name": "Junior Racket Hire",
+              "priceSpecification": {
+                "@type": "PriceSpecification",
+                "eligibleQuantity": {
+                  "@type": "QuantitativeValue",
+                  "minValue": 0,
+                  "maxValue": 4
+                }
+              },
+              "offers": [
+                {
+                  "@type": "Offer",
+                  "@id": "https://example.com/openactive/add-ons/b9372482-8d6e-4d89-9160-58fa52d86944#offer",
+                  "priceCurrency": "GBP",
+                  "price": 0
+                }
+              ]
+            }],
+            "provider": {
+              "@type": "Organization",
+              "@id": "https://example.com/api/venues/fe30c0e1-b4f9-4226-9fd8-3ddb230edd9f",
+              "name": "Sundridge Park Lawn Tennis & Squash Rackets Club"
+            }
+        }');
+        $this->assertInstanceOf(IndividualFacilityUse::class, $facility);
+        $this->assertCount(2, $facility->getAddOns());
+        $this->assertEquals('Adult Racket Hire', $facility->getAddOns()[0]->getName());
+        $this->assertEquals('Junior Racket Hire', $facility->getAddOns()[1]->getName());
+        $this->assertEquals('Football 11-a-side', $facility->getName());
+    }
+
+    public function testSerialises()
+    {
+        $facility = new IndividualFacilityUse([
+            'id' => 'https://example.com/api/openactive/individual-facility-uses/d7fb4341-756a-41a8-ad17-4b8f6b574bb6',
+            'identifier' => 'd7fb4341-756a-41a8-ad17-4b8f6b574bb6',
+            'name' => 'Football 11-a-side',
+            'url' => 'https://example.com/api/openactive/individual-facility-uses/d7fb4341-756a-41a8-ad17-4b8f6b574bb6',
+            'activity' => [new Concept([
+                'id' => 'https://openactive.io/activity-list#117e7f70-6c42-4b1f-a3bb-620b63ea263l',
+                'inScheme' => 'https://openactive.io/activity-list',
+                'prefLabel' => '11-a-side'
+            ])],
+            'addOns' => [
+                new AddOn([
+                    'id' => 'https://example.com/openactive/add-ons/de505ce7-351f-4f8f-90c4-29887947a603',
+                    'name' => 'Adult Racket Hire',
+                    'priceSpecification' => new PriceSpecification([
+                        'eligibleQuantity' => new QuantitativeValue([
+                            'minValue' => 0,
+                            'maxValue' => 4,
+                        ])
+                    ]),
+                    'offers' => [
+                        new Offer([
+                            'id' => 'https://example.com/openactive/add-ons/de505ce7-351f-4f8f-90c4-29887947a603#offer',
+                            'priceCurrency' => 'GBP',
+                            'price' => 1.5,
+                        ]),
+                    ]
+                ]),
+                new AddOn([
+                    'id' => 'https://example.com/openactive/add-ons/b9372482-8d6e-4d89-9160-58fa52d86944',
+                    'name' => 'Junior Racket Hire',
+                    'priceSpecification' => new PriceSpecification([
+                        'eligibleQuantity' => new QuantitativeValue([
+                            'minValue' => 0,
+                            'maxValue' => 4,
+                        ])
+                    ]),
+                    'offers' => [
+                        new Offer([
+                            'id' => 'https://example.com/openactive/add-ons/b9372482-8d6e-4d89-9160-58fa52d86944#offer',
+                            'priceCurrency' => 'GBP',
+                            'price' => 0,
+                        ]),
+                    ]
+                ]),
+            ],
+            'provider' => new Organization([
+                'id' => 'https://example.com/api/venues/fe30c0e1-b4f9-4226-9fd8-3ddb230edd9f',
+                'name' => 'Sundridge Park Lawn Tennis & Squash Rackets Club',
+            ]),
+        ]);
+        $this->assertJsonStringEqualsJsonString('{
+            "@id": "https://example.com/api/openactive/individual-facility-uses/d7fb4341-756a-41a8-ad17-4b8f6b574bb6",
+            "@type": "playfinder:IndividualFacilityUse",
+            "@context": [
+              "https://openactive.io/",
+              "https://openactive.io/ns-beta"
+            ],
+            "identifier": "d7fb4341-756a-41a8-ad17-4b8f6b574bb6",
+            "name": "Football 11-a-side",
+            "url": "https://example.com/api/openactive/individual-facility-uses/d7fb4341-756a-41a8-ad17-4b8f6b574bb6",
+            "activity": [
+              {
+                "@type": "Concept",
+                "@id": "https://openactive.io/activity-list#117e7f70-6c42-4b1f-a3bb-620b63ea263l",
+                "inScheme": "https://openactive.io/activity-list",
+                "prefLabel": "11-a-side"
+              }
+            ],
+            "beta:addOns": [{
+              "@id": "https://example.com/openactive/add-ons/de505ce7-351f-4f8f-90c4-29887947a603",
+              "@type": "playfinder:AddOn",
+              "name": "Adult Racket Hire",
+              "priceSpecification": {
+                "@type": "PriceSpecification",
+                "eligibleQuantity": {
+                  "@type": "QuantitativeValue",
+                  "minValue": 0,
+                  "maxValue": 4
+                }
+              },
+              "offers": [
+                {
+                  "@type": "Offer",
+                  "@id": "https://example.com/openactive/add-ons/de505ce7-351f-4f8f-90c4-29887947a603#offer",
+                  "priceCurrency": "GBP",
+                  "price": 1.5
+                }
+              ]
+            }, {
+              "@id": "https://example.com/openactive/add-ons/b9372482-8d6e-4d89-9160-58fa52d86944",
+              "@type": "playfinder:AddOn",
+              "name": "Junior Racket Hire",
+              "priceSpecification": {
+                "@type": "PriceSpecification",
+                "eligibleQuantity": {
+                  "@type": "QuantitativeValue",
+                  "minValue": 0,
+                  "maxValue": 4
+                }
+              },
+              "offers": [
+                {
+                  "@type": "Offer",
+                  "@id": "https://example.com/openactive/add-ons/b9372482-8d6e-4d89-9160-58fa52d86944#offer",
+                  "priceCurrency": "GBP",
+                  "price": 0
+                }
+              ]
+            }],
+            "provider": {
+              "@type": "Organization",
+              "@id": "https://example.com/api/venues/fe30c0e1-b4f9-4226-9fd8-3ddb230edd9f",
+              "name": "Sundridge Park Lawn Tennis & Squash Rackets Club"
+            }
+        }', IndividualFacilityUse::serialize($facility));
+    }
+}

--- a/tests/Models/Playfinder/OrderItemTest.php
+++ b/tests/Models/Playfinder/OrderItemTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace OpenActive\Models\Tests\Models\Playfinder;
+
+use OpenActive\Models\Playfinder\OrderItem;
+use PHPUnit\Framework\TestCase;
+
+class OrderItemTest extends TestCase
+{
+    public function testDeserialise()
+    {
+        $orderItem = OrderItem::deserialize('{
+          "@type": "playfinder:OrderItem",
+          "position": 1,
+          "orderQuantity": 1,
+          "acceptedOffer": "https://example.com/openactive/add-ons/de505ce7-351f-4f8f-90c4-29887947a603#offer",
+          "orderedItem": "https://example.com/openactive/add-ons/de505ce7-351f-4f8f-90c4-29887947a603",
+          "beta:parentOrderItem": {
+            "@type": "OrderItem",
+            "position": 0
+          }
+        }');
+        $this->assertInstanceOf(OrderItem::class, $orderItem);
+        $this->assertEquals(1, $orderItem->getPosition());
+        $this->assertEquals(1, $orderItem->getOrderQuantity());
+        $this->assertInstanceOf(\OpenActive\Models\OA\OrderItem::class, $orderItem->getParentOrderItem());
+        $this->assertEquals(0, $orderItem->getParentOrderItem()->getPosition());
+    }
+
+    public function testSerialise()
+    {
+        $orderItem = new OrderItem([
+            'position' => 1,
+            'orderQuantity' => 1,
+            'acceptedOffer' => 'https://example.com/openactive/add-ons/de505ce7-351f-4f8f-90c4-29887947a603#offer',
+            'orderedItem' => 'https://example.com/openactive/add-ons/de505ce7-351f-4f8f-90c4-29887947a603',
+            'parentOrderItem' => new OrderItem([
+                'position' => 0
+            ])
+        ]);
+        $this->assertJsonStringEqualsJsonString('{
+          "@type": "playfinder:OrderItem",
+          "@context": [
+              "https://openactive.io/",
+              "https://openactive.io/ns-beta"
+          ],
+          "position": 1,
+          "orderQuantity": 1,
+          "acceptedOffer": "https://example.com/openactive/add-ons/de505ce7-351f-4f8f-90c4-29887947a603#offer",
+          "orderedItem": "https://example.com/openactive/add-ons/de505ce7-351f-4f8f-90c4-29887947a603",
+          "beta:parentOrderItem": {
+            "@type": "playfinder:OrderItem",
+            "position": 0
+          }
+        }', OrderItem::serialize($orderItem));
+    }
+}

--- a/tests/Unit/Modifiers/AddOnModifierTest.php
+++ b/tests/Unit/Modifiers/AddOnModifierTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace OpenActive\Models\Tests\Unit\Modifiers;
+
+use OpenActive\Models\OA;
+use OpenActive\Models\Playfinder\OrderItem;
+use OpenActive\Modifiers\AddOnModifier;
+use PHPUnit\Framework\TestCase;
+
+class AddOnModifierTest extends TestCase
+{
+    public function testConvertsToPlayfinderModels()
+    {
+        $orderQuote = OA\OrderQuote::deserialize('{
+          "@context": "https://openactive.io/",
+          "@type": "OrderQuote",
+          "orderedItem": [
+            {
+              "@type": "OrderItem",
+              "position": 1,
+              "orderQuantity": 1,
+              "acceptedOffer": "https://example.com/openactive/add-ons/de505ce7-351f-4f8f-90c4-29887947a603#offer",
+              "orderedItem": "https://example.com/openactive/add-ons/de505ce7-351f-4f8f-90c4-29887947a603",
+              "beta:parentOrderItem": {
+                "@type": "OrderItem",
+                "position": 1
+              }
+            }
+          ]
+        }', [new AddOnModifier()]);
+        $this->assertInstanceOf(OA\OrderQuote::class, $orderQuote);
+        $this->assertCount(1, $orderQuote->getOrderedItem());
+        $this->assertInstanceOf(OrderItem::class, $orderQuote->getOrderedItem()[0]);
+        $this->assertInstanceOf(OA\OrderItem::class, $orderQuote->getOrderedItem()[0]->getParentOrderItem());
+    }
+}


### PR DESCRIPTION
Adds extra handling for new AddOn models to use this instead of the base Openactive models. Related to this Issue: https://github.com/openactive/open-booking-api/issues/224 but just going ahead as we can't wait on the documentation to catch up before just doing this. Use the `AddOnModifer` to map the models correctly for Order objects.